### PR TITLE
simplify the directory operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM amazonlinux:2
 
+
+WORKDIR /opt/app
+
 # Set up working directories
-RUN mkdir -p /opt/app
 RUN mkdir -p /opt/app/build
 RUN mkdir -p /opt/app/bin/
 
 # Copy in the lambda source
-WORKDIR /opt/app
 COPY ./*.py /opt/app/
 COPY requirements.txt /opt/app/requirements.txt
 


### PR DESCRIPTION
we don't need that additional `RUN` layer, so this simplifies things (`WORKDIR` runs `mkdir -p` under the hood anyway).